### PR TITLE
Fix div tag not being closed

### DIFF
--- a/includes/Traits/Admin.php
+++ b/includes/Traits/Admin.php
@@ -375,7 +375,7 @@ trait Admin
             'href'  => '#',
             'meta'  => [
                 'class' => 'ea-clear-cache',
-                'html'   => '<div class="ea-clear-cache-id" data-pageid="'.get_queried_object_id().'">'
+                'html'   => '<div class="ea-clear-cache-id" data-pageid="'.get_queried_object_id().'"></div>'
             ],
             'title' => 'Regenerate Page Assets'
         ]);


### PR DESCRIPTION
Admin menu item does not have a closing div tag which is invalid markup. It has a chain reaction that is not playing nice with my own code due to being it strict on HTML.

Thanks